### PR TITLE
Update peer dependency on semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "files": ["dist/**/*"],
   "peerDependencies": {
     "date-fns": "^2.30.0",
-    "semantic-release": "^19.0.0"
+    "semantic-release": ">=19.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",


### PR DESCRIPTION
Update peer dependency to allow plugin to install when using major versions higher than 19