### PR TITLE
ci(workflows): update node versions and add git fetch args for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Checkout Code
@@ -76,4 +76,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_FETCH_EXTRA_ARGS: '--prune --tags'
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,7 @@
   "branches": ["main"],
   "tagFormat": "v${version}",
   "plugins": [
+    "@mrbernnz/semantic-release-calver",
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
@@ -16,7 +17,8 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+        "GIT_FETCH_EXTRA_ARGS": "--prune --tags"
       }
     ],
     [

--- a/package.json
+++ b/package.json
@@ -49,15 +49,7 @@
   },
   "release": {
     "branches": [
-      "main",
-      {
-        "name": "beta",
-        "prerelease": true
-      },
-      {
-        "name": "alpha",
-        "prerelease": true
-      }
+      "main"
     ]
   },
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export const prepare = async (
     const lastVersion = context.lastRelease?.version;
     const versionManager = new VersionManager(pluginConfig.versionFormat);
 
-    if (!versionManager.isValidVersion(lastVersion)) {
+    if (lastVersion && !versionManager.isValidVersion(lastVersion)) {
       throw new SemanticReleaseError(
         'Invalid Version Format',
         'EINVALIDVERSION',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export class VersionManager {
     const formattedDate = this.getFormattedDate();
 
     if (!lastVersion) {
-      return `${formattedDate}.0`;
+      return `${formattedDate}.1`;
     }
 
     const versionSegments = this.getVersionSegments(lastVersion);


### PR DESCRIPTION
- Updated GitHub Actions matrix to test on Node 20.x and 22.x only
- Added GIT_FETCH_EXTRA_ARGS '--prune --tags' to publish workflow environment
- Configured semantic-release git plugin to use '--prune --tags' fetch args
- Removed beta and alpha prerelease branches from package.json release config
- Fixed version validation to check lastVersion existence before validation
- Changed initial version suffix from .0 to .1 for new releases