### PR TITLE
fix: run calver override in verifyRelease for dry-run support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import SemanticReleaseError from '@semantic-release/error';
-import {GenerateNotesContext, PluginConfig, PrepareContext} from './types';
+import {GenerateNotesContext, PluginConfig, VerifyReleaseContext} from './types';
 import {VersionManager} from './utils';
 
 /**
@@ -14,13 +14,15 @@ export const generateNotes = async (
 ): Promise<string | undefined> => context.nextRelease?.notes;
 
 /**
- * Prepares the next release by calculating the next version.
+ * Verifies and finalizes the next release version, overwriting the SemVer
+ * default with a CalVer version. Runs during `verifyRelease`, which
+ * semantic-release always executes (even in `--dry-run`), unlike `prepare`.
  * @param pluginConfig - Plugin configuration.
  * @param context - Plugin context containing release data.
  */
-export const prepare = async (
+export const verifyRelease = async (
   pluginConfig: PluginConfig = {versionFormat: 'YYYY.0M.MICRO'},
-  context: PrepareContext
+  context: VerifyReleaseContext
 ): Promise<void> => {
   try {
     const lastVersion = context.lastRelease?.version;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface DetermineFormatArgs {
   versionFormat: VersionFormat;
 }
 
-export {GenerateNotesContext, PrepareContext} from 'semantic-release';
+export {GenerateNotesContext, VerifyReleaseContext} from 'semantic-release';
 
 export type VersionFormat = 'YYYY.0M.MICRO' | 'YYYY.0M_MICRO';
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,9 +1,9 @@
 import SemanticReleaseError from '@semantic-release/error';
 import {Signale} from 'signale';
-import {generateNotes, prepare} from '../src/index';
-import {GenerateNotesContext, PluginConfig, PrepareContext} from '../src/types';
+import {generateNotes, verifyRelease} from '../src/index';
+import {GenerateNotesContext, PluginConfig, VerifyReleaseContext} from '../src/types';
 
-type Context = GenerateNotesContext | PrepareContext;
+type Context = GenerateNotesContext | VerifyReleaseContext;
 
 describe('Calver Plugin', () => {
   let mockLogger: jest.Mocked<Signale<'error' | 'success' | 'warn' | 'log'>>;
@@ -82,14 +82,14 @@ describe('Calver Plugin', () => {
     });
   });
 
-  describe('prepare function', () => {
+  describe('verifyRelease function', () => {
     const date = new Date();
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
 
     describe('with default version format', () => {
       it('should sets next version correctly', async () => {
-        await prepare(mockPluginConfig, mockContext);
+        await verifyRelease(mockPluginConfig, mockContext);
 
         const re = new RegExp(`${year}\.${month}([_.]\\d+)?$`);
 
@@ -100,7 +100,7 @@ describe('Calver Plugin', () => {
       it('should increment minor version for the same month', async () => {
         mockContext.lastRelease.version = `${year}.${month}.3`;
 
-        await prepare(mockPluginConfig, mockContext);
+        await verifyRelease(mockPluginConfig, mockContext);
 
         expect(mockContext.nextRelease.version).toBe(`${year}.${month}.4`);
       });
@@ -108,17 +108,28 @@ describe('Calver Plugin', () => {
       it('should reset minor version for a new month', async () => {
         mockContext.lastRelease.version = '2024.11.3';
 
-        await prepare(mockPluginConfig, mockContext);
+        await verifyRelease(mockPluginConfig, mockContext);
 
         const re = new RegExp(`${year}\.${month}.\\d{1}`);
 
         expect(mockContext.nextRelease.version).toMatch(re);
       });
 
+      it('should overwrite a SemVer default version set by semantic-release core (dry-run regression)', async () => {
+        mockContext.nextRelease.version = '1.0.0';
+
+        await verifyRelease(mockPluginConfig, mockContext);
+
+        const re = new RegExp(`${year}\.${month}([_.]\\d+)?$`);
+
+        expect(mockContext.nextRelease.version).not.toBe('1.0.0');
+        expect(mockContext.nextRelease.version).toMatch(re);
+      });
+
       it.skip.failing('should convert semver version', async () => {
         mockContext.lastRelease.version = '1.2.3';
 
-        await prepare(mockPluginConfig, mockContext);
+        await verifyRelease(mockPluginConfig, mockContext);
 
         const re = new RegExp(`${year}\.${month}([._]\\d+)?$`);
 
@@ -140,7 +151,7 @@ describe('Calver Plugin', () => {
           mockContext.lastRelease.version = version;
           const error = new SemanticReleaseError(errorMessage);
 
-          await expect(prepare(mockPluginConfig, mockContext)).rejects.toThrow({
+          await expect(verifyRelease(mockPluginConfig, mockContext)).rejects.toThrow({
             name: errorName,
             message: errorMessage
           });


### PR DESCRIPTION
## Description
`semantic-release` marks the `prepare` hook as `dryRun: false`, so it is skipped
entirely during `--dry-run`, leaving `nextRelease.version` at the plain SemVer
default instead of the CalVer value this plugin is supposed to produce.

This PR moves the version override from the `prepare` hook to `verifyRelease`,
which always runs (dry-run or not) and already has `nextRelease` populated.
The exported `prepare` function is renamed to `verifyRelease`, and
`PrepareContext` is swapped for `VerifyReleaseContext` (a structurally
identical type) throughout `src/` and `tests/`. As a side effect, this also
fixes release notes being generated against the un-overwritten SemVer version
on normal (non-dry-run) releases, since `generateNotes` now runs after the
CalVer version is set instead of before.

## Related Issue
Closes PRO-48

## Motivation and Context
Running `semantic-release --dry-run` printed `1.0.0` instead of a CalVer
version, making dry-run output misleading and unusable for previewing the
next release version.

## How Has This Been Tested?
- Traced the exact lifecycle in `semantic-release`'s own source
  (`lib/definitions/plugins.js`, `index.js`) to confirm `verifyRelease` runs
  unconditionally while `prepare` is skipped under `--dry-run`.
- Added a regression test that seeds `nextRelease.version` with the SemVer
  default and asserts it gets overwritten to the CalVer format.
- `yarn jest tests/index.test.ts` — all tests pass.
- `yarn tsc --noEmit` — compiles cleanly with no new errors.

## Screenshots (if appropriate):
N/A — no UI changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style guidelines of this project.
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the documentation accordingly.

No documentation changes were needed — `README.md` doesn't reference the
`prepare`/`verifyRelease` hook name, and `semantic-release` auto-wires
whichever hook names a plugin module exports.