### PR TITLE
fix: migrate pre-existing SemVer releases to CalVer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,15 +28,22 @@ export const verifyRelease = async (
     const lastVersion = context.lastRelease?.version;
     const versionManager = new VersionManager(pluginConfig.versionFormat);
 
+    let calverBaseVersion: string | undefined = lastVersion;
+
     if (lastVersion && !versionManager.isValidVersion(lastVersion)) {
-      throw new SemanticReleaseError(
-        'Invalid Version Format',
-        'EINVALIDVERSION',
-        `The version "${lastVersion}" is not a valid SemVer or CalVer.`
-      );
+      if (!versionManager.isSemVer(lastVersion)) {
+        throw new SemanticReleaseError(
+          'Invalid Version Format',
+          'EINVALIDVERSION',
+          `The version "${lastVersion}" is not a valid SemVer or CalVer.`
+        );
+      }
+
+      context.logger.log(`Detected SemVer last release "${lastVersion}"; migrating to CalVer.`);
+      calverBaseVersion = undefined;
     }
 
-    const newVersion = versionManager.calculateNextVersion(lastVersion);
+    const newVersion = versionManager.calculateNextVersion(calverBaseVersion);
 
     if (context.nextRelease) {
       context.nextRelease.version = newVersion;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,6 +42,17 @@ export class VersionManager {
   }
 
   /**
+   * Determines whether a version string is a valid SemVer version, regardless
+   * of whether it is also CalVer-shaped. Used to detect a pre-existing SemVer
+   * release history that predates CalVer adoption.
+   * @param version - The version string to check.
+   * @returns `true` if valid SemVer, otherwise `false`.
+   */
+  isSemVer(version: string): boolean {
+    return semver.valid(version, {loose: true}) !== null;
+  }
+
+  /**
    * Calculates the next version following CalVer (i.e. YYYY.0M.MICRO).
    * @param lastVersion - The last version string (e.g., "2024.12.3").
    * @returns The next version string.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -126,7 +126,7 @@ describe('Calver Plugin', () => {
         expect(mockContext.nextRelease.version).toMatch(re);
       });
 
-      it.skip.failing('should convert semver version', async () => {
+      it('should convert semver version', async () => {
         mockContext.lastRelease.version = '1.2.3';
 
         await verifyRelease(mockPluginConfig, mockContext);


### PR DESCRIPTION
## Summary
- `verifyRelease` hard-failed with `EINVALIDVERSION` whenever `lastRelease.version` was a real SemVer (e.g. `0.3.1`) but not CalVer-shaped, blocking adoption on any repo with pre-existing SemVer tags — including this repo's own last tag `v0.3.1`.
- Added `VersionManager.isSemVer()` and a migration branch in `verifyRelease`: a SemVer-but-not-CalVer `lastRelease.version` is now treated as "no last release" and bootstrapped fresh into CalVer instead of throwing.
- Unskipped the `'should convert semver version'` regression test that covers this case.

## Test plan
- [x] `npm test` — full suite passes (35 tests, 4 pre-existing unrelated skips)
- [x] `npm run build` — `tsc` compiles cleanly