### PR TITLE
fix(version): distinguish invalid CalVer from unrecognized version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,16 +31,22 @@ export const verifyRelease = async (
     let calverBaseVersion: string | undefined = lastVersion;
 
     if (lastVersion && !versionManager.isValidVersion(lastVersion)) {
-      if (!versionManager.isSemVer(lastVersion)) {
+      if (versionManager.isSemVer(lastVersion)) {
+        context.logger.log(`Detected SemVer last release "${lastVersion}"; migrating to CalVer.`);
+        calverBaseVersion = undefined;
+      } else if (versionManager.isCalVerShaped(lastVersion)) {
+        throw new SemanticReleaseError(
+          'Invalid CalVer Format',
+          'EINVALIDCALVER',
+          `The version "${lastVersion}" looks like CalVer but does not match the expected "${pluginConfig.versionFormat}" pattern.`
+        );
+      } else {
         throw new SemanticReleaseError(
           'Invalid Version Format',
           'EINVALIDVERSION',
           `The version "${lastVersion}" is not a valid SemVer or CalVer.`
         );
       }
-
-      context.logger.log(`Detected SemVer last release "${lastVersion}"; migrating to CalVer.`);
-      calverBaseVersion = undefined;
     }
 
     const newVersion = versionManager.calculateNextVersion(calverBaseVersion);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,30 @@ export class VersionManager {
   }
 
   /**
+   * Determines whether a version string is CalVer-shaped - i.e. its first two
+   * segments read as a plausible year and zero-padded month - even though it
+   * fails full `isValidVersion` validation (e.g. a missing MICRO segment).
+   * @param version - The version string to check.
+   * @returns `true` if the leading segments look like YYYY and 0M, otherwise `false`.
+   */
+  isCalVerShaped(version: string): boolean {
+    const [yearStr, monthStr] = this.getVersionSegments(version);
+    if (!yearStr || !monthStr) return false;
+
+    const year = Number(yearStr);
+    if (!/^\d+$/.test(yearStr) || Number.isNaN(year) || year < 2000 || year > new Date().getFullYear()) {
+      return false;
+    }
+
+    const month = Number(monthStr);
+    if (!/^\d{2}$/.test(monthStr) || Number.isNaN(month) || month < 1 || month > 12) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Calculates the next version following CalVer (i.e. YYYY.0M.MICRO).
    * @param lastVersion - The last version string (e.g., "2024.12.3").
    * @returns The next version string.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -169,7 +169,7 @@ describe('Calver Plugin', () => {
     });
 
     describe('with an invalid version', () => {
-      test.skip.failing.each`
+      test.each`
         version                     | errorName                 | errorMessage
         ${'random-string'}          | ${'SemanticReleaseError'} | ${'Invalid Version Format'}
         ${'random.invalid.version'} | ${'SemanticReleaseError'} | ${'Invalid Version Format'}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -29,6 +29,22 @@ describe('CalVer Plugin Utils', () => {
     });
   });
 
+  describe('isCalVerShaped', () => {
+    it.each`
+      version                     | expected
+      ${''}                       | ${false}
+      ${'random-string'}          | ${false}
+      ${'random.invalid.version'} | ${false}
+      ${'24.11'}                  | ${false}
+      ${'2024.11'}                | ${true}
+      ${'2024.11.3'}              | ${true}
+      ${'2024.11.abc'}            | ${true}
+      ${'1999.11'}                | ${false}
+    `('should evaluate "$version" as CalVer-shaped: "$expected"', async ({version, expected}) => {
+      expect(versionManager.isCalVerShaped(version)).toEqual(expected);
+    });
+  });
+
   describe('determineFormat', () => {
     const formattedDate = versionManager['getFormattedDate']();
 


### PR DESCRIPTION
## Summary
- Adds `VersionManager.isCalVerShaped()`, which checks whether a version's leading year/month segments are plausible CalVer, even if the full version fails validation (e.g. a missing MICRO segment).
- Wires this into `verifyRelease`: SemVer-migration detection still takes precedence, then CalVer-shaped-but-malformed versions throw a distinct `Invalid CalVer Format` error, and everything else falls back to the existing `Invalid Version Format` error.
- Un-skips the previously disabled `tests/index.test.ts` table test and adds new `isCalVerShaped` unit test cases.

## Test plan
- [x] `npm test` — 48/48 passing
- [x] `tsc --noEmit` — clean
- [x] `npm run build` — clean